### PR TITLE
statically link to llvmdev

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,13 @@ cd ${SRC_DIR}
 export PYTHONNOUSERSITE=1
 
 export LLVMLITE_USE_CMAKE=1
-export LLVMLITE_SHARED=1
+
+# Having two different versions of libLLVM in the same process is causing segfaults, this is 
+# achieved in practice by e.g. using Numba->llvmlite->libllvm15.so in the same process as 
+# Pytorch->libLLVM19.so (or something else using a different version of LLVM).
+# llvmlite is the only package on main having a dependency on llvmdev 15. 
+# Statically linking against llvm prevents a point of collision.
+# see https://anaconda.atlassian.net/browse/PKG-7254
+export LLVMLITE_SHARED=0
 
 $PYTHON -m pip install . --no-deps  --no-build-isolation --ignore-installed -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/llvmlite-{{ version }}.tar.gz
   sha256: 07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310 or s390x]
   script_env:
     - PY_VCRUNTIME_REDIST
@@ -25,13 +25,14 @@ requirements:
     - pip
     - setuptools
     - wheel
+    # Statically linking to llvmdev ! see comments in build.sh
     - llvmdev 15.*
-    - llvm 15.*
     # zlib on win because our llvmdev is not built with LLVM_ENABLE_ZLIB=OFF
-    - zlib {{ zlib }} # [win]
+    # zlib on others because we are statically linking to llvmdev
+    - zlib {{ zlib }}
   run:
     - python
-    - zlib # [win] through run_exports
+    - zlib # bounds through run_exports
 
 test:
   requires:
@@ -46,6 +47,8 @@ test:
     - export LLVMLITE_DIST_TEST=''  # [unix]
     - set LLVMLITE_DIST_TEST=""     # [win]
     - python -m llvmlite.tests
+  downstreams:
+    - numba
 
 about:
   home: https://llvmlite.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,13 @@ requirements:
     # Statically linking to llvmdev ! see comments in build.sh
     - llvmdev 15.*
     # zlib on win because our llvmdev is not built with LLVM_ENABLE_ZLIB=OFF
-    # zlib on others because we are statically linking to llvmdev
+    # zlib and zstd on others because we are statically linking to llvmdev
     - zlib {{ zlib }}
+    - zstd {{ zstd }}
   run:
     - python
     - zlib # bounds through run_exports
+    - zstd # bounds through run_exports
 
 test:
   requires:


### PR DESCRIPTION
statically link to llvmdev

Having two different versions of libLLVM in the same process is causing segfaults, this is achieved in practice by e.g. using Numba->llvmlite->libllvm15.so in the same process as Pytorch->libLLVM19.so (or something else using a different version of LLVM). llvmlite is the only package on main having a dependency on llvmdev 15. Statically linking against llvm prevents a point of collision.

see https://anaconda.atlassian.net/browse/PKG-7254