### PR TITLE
Ignore run_exports from llvmdev

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,11 @@ source:
     - patches/0001-use-conda-env.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
+  # We are statically linking to llvmdev
+  ignore_run_exports_from:
+    - llvmdev
   script_env:
     - PY_VCRUNTIME_REDIST
 


### PR DESCRIPTION
llvmlite rebuild

**Destination channel:** defaults

### Links

- [PKG-14769](https://anaconda.atlassian.net/browse/PKG-14769) 


### Explanation of changes:

- Bump build number
- Add `ignore_run_exports_from` llvmdev to prevent forcing inclusion of llvm. We are intentionally statically linking to prevent this from being required. 


[PKG-14769]: https://anaconda.atlassian.net/browse/PKG-14769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ